### PR TITLE
Update factory contracts to deploy EIP-1167 minimal proxies

### DIFF
--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -7,6 +7,7 @@ import "./Administratable.sol";
 import "./OrgFactory.sol";
 import "./interfaces/IFactory.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
 
 // FUND CONTRACT
 /**
@@ -19,7 +20,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
  * a SafeMath transfer of a 1% fee to the EndaomentAdmin and the remainder to the
  * recipient Org contract.
  */
-contract Fund is Administratable {
+contract Fund is Initializable, Administratable {
   using SafeMath for uint256;
   using SafeERC20 for IERC20;
 
@@ -47,10 +48,12 @@ contract Fund is Administratable {
   // ========== CONSTRUCTOR ==========
   /**
    * @notice Create new Fund
+   * @dev Using initializer instead of constructor for minimal proxy support. This function
+   * can only be called once in the contract's lifetime
    * @param fundManager Address of the Fund's Primary Advisor
    * @param fundFactory Address of the Factory contract.
    */
-  constructor(address fundManager, address fundFactory) public {
+  function initializeFund(address fundManager, address fundFactory) public initializer {
     require(fundManager != address(0), "Fund: Creator cannot be null address.");
     require(fundFactory != address(0), "Fund: Factory cannot be null address.");
     manager = fundManager;

--- a/contracts/FundFactory.sol
+++ b/contracts/FundFactory.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.6.10;
 
 import "./EndaomentAdminStorage.sol";
 import "./Fund.sol";
+import "./ProxyFactory.sol";
 
 // FUND FACTORY CONTRACT
 /**
@@ -12,9 +13,14 @@ import "./Fund.sol";
  * @notice FundFactory is a contract that allows the Endaoment ADMIN or ACCOUNTANT to
  * instantiate new Fund contracts.
  */
-contract FundFactory is EndaomentAdminStorage {
+contract FundFactory is ProxyFactory, EndaomentAdminStorage {
   // ========== EVENTS ==========
   event FundCreated(address indexed newAddress);
+  event FundLogicDeployed(address logicAddress);
+
+  // ========== STATE VARIABLES==========
+
+  address public immutable fundLogic; // logic template for all Fund contracts
 
   // ========== CONSTRUCTOR ==========
   /**
@@ -22,9 +28,21 @@ contract FundFactory is EndaomentAdminStorage {
    * @param adminContractAddress Address of EndaomentAdmin contract.
    */
   constructor(address adminContractAddress) public {
+    // Set endaoment admin
     require(adminContractAddress != address(0), "FundFactory: Admin cannot be the zero address");
     endaomentAdmin = adminContractAddress;
     emit EndaomentAdminChanged(address(0), adminContractAddress);
+
+    // Deploy and initialize Fund logic contract (used to deploy minimal proxies in createFund)
+    // We set the address of the fund manager to whoever deployed this contract. Since this
+    // instance will not be used as anything other than a logic template, the address used
+    // as the fund manager does not matter much
+    Fund fundLogicContract = new Fund();
+    fundLogicContract.initializeFund(msg.sender, address(this));
+
+    // Save off address so we can reference for all future deployments
+    fundLogic = address(fundLogicContract);
+    emit FundLogicDeployed(address(fundLogicContract));
   }
 
   // ========== Fund Creation & Management ==========
@@ -37,7 +55,12 @@ contract FundFactory is EndaomentAdminStorage {
     onlyAdminOrRole(endaomentAdmin, IEndaomentAdmin.Role.ACCOUNTANT)
   {
     require(managerAddress != address(0), "FundFactory: Manager cannot be the zero address");
-    Fund newFund = new Fund(managerAddress, address(this));
-    emit FundCreated(address(newFund));
+    bytes memory payload = abi.encodeWithSignature(
+      "initializeFund(address,address)",
+      managerAddress,
+      address(this)
+    );
+    address newFund = deployMinimal(fundLogic, payload);
+    emit FundCreated(newFund);
   }
 }

--- a/contracts/Org.sol
+++ b/contracts/Org.sol
@@ -7,6 +7,7 @@ import "./Administratable.sol";
 import "./interfaces/IFactory.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
 
 //ORG CONTRACT
 /**
@@ -17,7 +18,7 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
  * and allows for an address to submit a Claim struct to the contract whereby
  * the organization can directly receive grant awards from Endaoment Funds.
  */
-contract Org is Administratable {
+contract Org is Initializable, Administratable {
   using SafeERC20 for IERC20;
 
   // ========== STRUCTS & EVENTS ==========
@@ -44,11 +45,12 @@ contract Org is Administratable {
 
   /**
    * @notice Create new Organization Contract
+   * @dev Using initializer instead of constructor for minimal proxy support. This function
+   * can only be called once in the contract's lifetime
    * @param ein The U.S. Tax Identification Number for the Organization
    * @param orgFactory Address of the Factory contract.
    */
-  constructor(uint256 ein, address orgFactory) public {
-    require(ein >= 10000000 && ein <= 999999999, "Org: Must provide a valid EIN");
+  function initializeOrg(uint256 ein, address orgFactory) public initializer {
     require(orgFactory != address(0), "Org: Factory cannot be null address.");
     taxId = ein;
     orgFactoryContract = IFactory(orgFactory);

--- a/contracts/OrgFactory.sol
+++ b/contracts/OrgFactory.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.6.10;
 
 import "./EndaomentAdminStorage.sol";
 import "./Org.sol";
+import "./ProxyFactory.sol";
 
 //ORG FACTORY CONTRACT
 /**
@@ -14,15 +15,17 @@ import "./Org.sol";
  * individual Org contract addresses as well as a list of all
  * allowedOrgs.
  */
-contract OrgFactory is EndaomentAdminStorage {
+contract OrgFactory is ProxyFactory, EndaomentAdminStorage {
   // ========== EVENTS===================
 
   event OrgCreated(address indexed newAddress);
   event OrgStatusChanged(address indexed orgAddress, bool indexed isAllowed);
+  event OrgLogicDeployed(address logicAddress);
 
   // ========== STATE VARIABLES==========
 
   mapping(address => bool) public allowedOrgs;
+  address public immutable orgLogic; // logic template for all Org contracts
 
   // ========== CONSTRUCTOR ==========
   /**
@@ -30,9 +33,21 @@ contract OrgFactory is EndaomentAdminStorage {
    * @param adminContractAddress Address of EndaomentAdmin contract.
    */
   constructor(address adminContractAddress) public {
+    // Set endaoment admin
     require(adminContractAddress != address(0), "OrgFactory: Admin cannot be the zero address");
     endaomentAdmin = adminContractAddress;
     emit EndaomentAdminChanged(address(0), adminContractAddress);
+
+    // Deploy and initialize Org logic contract (used to deploy minimal proxies in createOrg)
+    // We set the EIN to 999999999, since it is unlikely to be a real EIN. Even if it is a real
+    // EIN, that is ok because (1) there is no check against duplicate EINs, and (2) this instance
+    // is not used as anything other than a logic template, so the EIN value doesn't matter
+    Org orgLogicContract = new Org();
+    orgLogicContract.initializeOrg(999999999, address(this));
+
+    // Save off address so we can reference for all future deployments
+    orgLogic = address(orgLogicContract);
+    emit OrgLogicDeployed(address(orgLogicContract));
   }
 
   // ========== Org Creation & Management ==========
@@ -44,9 +59,16 @@ contract OrgFactory is EndaomentAdminStorage {
     public
     onlyAdminOrRole(endaomentAdmin, IEndaomentAdmin.Role.ACCOUNTANT)
   {
-    Org newOrg = new Org(ein, address(this));
-    allowedOrgs[address(newOrg)] = true;
-    emit OrgCreated(address(newOrg));
+    require(ein >= 10000000 && ein <= 999999999, "Org: Must provide a valid EIN");
+    bytes memory payload = abi.encodeWithSignature(
+      "initializeOrg(uint256,address)",
+      ein,
+      address(this)
+    );
+    address newOrg = deployMinimal(orgLogic, payload);
+
+    allowedOrgs[newOrg] = true;
+    emit OrgCreated(newOrg);
   }
 
   /**

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -6,7 +6,7 @@ contract ProxyFactory {
    * @dev This function enables deployment of EIP-1167 minimal proxies. The code below
    * was copied from the OpenZeppelin ProxyFactory.sol contract, as there is currently
    * no package that has a version compatible with Solidity ^0.6.0. At the time of writing
-   * copy/pasting the file in this manner is considered the best practive for ^0.6.0:
+   * copy/pasting the file in this manner is considered the best practice for ^0.6.0:
    *   https://forum.openzeppelin.com/t/best-practice-for-using-proxyfactory-sol-in-a-solidity-0-6-project-deploying-minimal-proxies/3478
    *
    * EIP-1167 references:

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.7;
+
+contract ProxyFactory {
+  /**
+   * @dev This function enables deployment of EIP-1167 minimal proxies. The code below
+   * was copied from the OpenZeppelin ProxyFactory.sol contract, as there is currently
+   * no package that has a version compatible with Solidity ^0.6.0. At the time of writing
+   * copy/pasting the file in this manner is considered the best practive for ^0.6.0:
+   *   https://forum.openzeppelin.com/t/best-practice-for-using-proxyfactory-sol-in-a-solidity-0-6-project-deploying-minimal-proxies/3478
+   *
+   * EIP-1167 references:
+   *   The EIP and associated CloneFactory repo
+   *     - https://eips.ethereum.org/EIPS/eip-1167
+   *   Open Zeppelin blog post and discussion
+   *     - https://blog.openzeppelin.com/deep-dive-into-the-minimal-proxy-contract/
+   *     - https://forum.openzeppelin.com/t/deep-dive-into-the-minimal-proxy-contract/1928
+   */
+  function deployMinimal(address _logic, bytes memory _data) public returns (address proxy) {
+    // Adapted from https://github.com/optionality/clone-factory/blob/32782f82dfc5a00d103a7e61a17a5dedbd1e8e9d/contracts/CloneFactory.sol
+    bytes20 targetBytes = bytes20(_logic);
+    assembly {
+      let clone := mload(0x40)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+      proxy := create(0, clone, 0x37)
+    }
+
+    if (_data.length > 0) {
+      (bool success, ) = proxy.call(_data);
+      require(success, "ProxyFactory: Initialization of proxy failed");
+    }
+  }
+}

--- a/test/Fund.test.js
+++ b/test/Fund.test.js
@@ -58,14 +58,6 @@ describe("Fund", function () {
     assert.isDefined(fund.logs[0].args.newAddress);
   });
 
-  it("denies invalid admin contract to construct fund contract", async function () {
-    await expectRevert.unspecified(
-      Fund.new(constants.ZERO_ADDRESS, this.endaomentAdmin.address, {
-        from: admin,
-      })
-    );
-  });
-
   it("creates funds with correct manager", async function () {
     const fundContract = await Fund.at(this.fund.address);
     const fundManager = await fundContract.manager();


### PR DESCRIPTION
`FundFactory` and `OrgFactory` now deploy their child contracts as EIP-1167 minimal proxies. 

## Results

Based on 100 gwei and current ETH prices:
- FundFactory `createFund()` costs reduced from 3,316,299 gas ($146.25) to 141,634 gas ($6.25)
- OrgFactory `createOrg()` costs reduced from 2,770,298 gas ($122.17) to 161,382 gas ($7.12)

## Details

- Added a new contract called `ProxyFactory.sol`. This is the main contract doing all the work. For Solidity ^0.6.0, [the current recommended best practice](https://forum.openzeppelin.com/t/best-practice-for-using-proxyfactory-sol-in-a-solidity-0-6-project-deploying-minimal-proxies/3478) by OpenZeppelin is to copy/paste the file, since they do not yet have a ^0.6.0 package for this contract
- Constructors were changed to ordinary functions that have a special modifier that only allows those functions to be called once in the contract's lifetime. This is required because minimal proxy deployments differ from traditional deployments and do not call a constructor
- EIN verification is now done in `OrgFactory` instead of `Org`. This is because the function used to deploy a minimal proxy will check if the initialization call was successful. If it doesn't, it throws with the error "ProxyFactory: Initialization of proxy failed". We want it to throw with "Org: Must provide a valid EIN", which requires the check to be moved to the factory
- Removed the "denies invalid admin contract to construct fund contract" test since it fails with the new architecture and isn't too useful of a test anyway